### PR TITLE
Add fuzzy search box to interface

### DIFF
--- a/assets/lib/fuzzy.min.js
+++ b/assets/lib/fuzzy.min.js
@@ -1,0 +1,8 @@
+/*
+ * Fuzzy
+ * https://github.com/mattyork/fuzzy
+ *
+ * Copyright (c) 2015 Matt York
+ * Licensed under the MIT license.
+ */
+(function(){var root=this;var fuzzy={};if(typeof exports!=="undefined"){module.exports=fuzzy}else{root.fuzzy=fuzzy}fuzzy.simpleFilter=function(pattern,array){return array.filter(function(string){return fuzzy.test(pattern,string)})};fuzzy.test=function(pattern,string){return fuzzy.match(pattern,string)!==null};fuzzy.match=function(pattern,string,opts){opts=opts||{};var patternIdx=0,result=[],len=string.length,totalScore=0,currScore=0,pre=opts.pre||"",post=opts.post||"",compareString=opts.caseSensitive&&string||string.toLowerCase(),ch,compareChar;pattern=opts.caseSensitive&&pattern||pattern.toLowerCase();for(var idx=0;idx<len;idx++){ch=string[idx];if(compareString[idx]===pattern[patternIdx]){ch=pre+ch+post;patternIdx+=1;currScore+=1+currScore}else{currScore=0}totalScore+=currScore;result[result.length]=ch}if(patternIdx===pattern.length){return{rendered:result.join(""),score:totalScore}}return null};fuzzy.filter=function(pattern,arr,opts){opts=opts||{};return arr.reduce(function(prev,element,idx,arr){var str=element;if(opts.extract){str=opts.extract(element)}var rendered=fuzzy.match(pattern,str,opts);if(rendered!=null){prev[prev.length]={string:rendered.rendered,score:rendered.score,index:idx,original:element}}return prev},[]).sort(function(a,b){var compare=b.score-a.score;if(compare)return compare;return a.index-b.index})}})();

--- a/index.html
+++ b/index.html
@@ -162,9 +162,6 @@
         .attr("x", -overlaySize)
         .attr("y", -overlaySize);
 
-
-    var all = []; // store all labels for fast search.
-
     var node, link, text, graphSource;
 
     var nodeColors = {
@@ -267,9 +264,6 @@
             .text(function(d) { return d.name.substring(0, 20);});
 
         catchLocationHash(true);
-        all = d3.selectAll('.node')[0].map(function(x) {
-            return x.textContent;
-        });
     }
 
     function selectNode(d, focus) {
@@ -350,17 +344,21 @@
             return;
         }
 
-        var matches = fuzzy.filter(this.value, all).sort(function (a, b) {
-            a.ratio = a.score / a.string.length;
-            b.ratio = b.score / b.string.length;
-            if (a.ratio > b.ratio) {
-                return -1;
-            }
-            if (a.ratio < b.ratio) {
-                return 1;
-            }
-            return 0;
-        });
+        var matches = fuzzy
+            .filter(this.value,
+                    d3.selectAll('.node')[0],
+                    { extract: function (x) { return x.textContent; } })
+            .sort(function (a, b) {
+                a.ratio = a.score / a.string.length;
+                b.ratio = b.score / b.string.length;
+                if (a.ratio > b.ratio) {
+                    return -1;
+                }
+                if (a.ratio < b.ratio) {
+                    return 1;
+                }
+                return 0;
+            });
 
         if (matches.length > 0) {
             d3.selectAll(".node").each(function (d) {

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <title>Programming Language Network</title>
     <script src="assets/lib/d3.v3.min.js"></script>
+    <script src="assets/lib/fuzzy.min.js"></script>
     <style type="text/css">
         body {
             margin: 0;
@@ -97,6 +98,19 @@
             background: purple;
             margin-left: -25px;
         }
+
+        .search-box {
+          padding: 0 20px 0 20px;
+        }
+        .search {
+          width: 100%;
+          background-color: transparent;
+          border-style: solid;
+          border-width: 0px 0px 1px 0px;
+          border-color: white;
+          color: #b3b3b3;
+          font-size: 15px;
+        }
     </style>
 </head>
 <body>
@@ -112,6 +126,10 @@
     <ul class="nodes-info"></ul>
     <h3>Edges</h3>
     <ul class="edges-info"></ul>
+    <h3>Search</h3>
+    <div class="search-box">
+      <input type="search" class="search">
+    </div>
 </div>
 <script type="text/javascript">
     var width = window.innerWidth,
@@ -143,6 +161,9 @@
         .attr("height", (height * 10) + overlaySize)
         .attr("x", -overlaySize)
         .attr("y", -overlaySize);
+
+
+    var all = []; // store all labels for fast search.
 
     var node, link, text, graphSource;
 
@@ -246,6 +267,9 @@
             .text(function(d) { return d.name.substring(0, 20);});
 
         catchLocationHash(true);
+        all = d3.selectAll('.node')[0].map(function(x) {
+            return x.textContent;
+        });
     }
 
     function selectNode(d, focus) {
@@ -320,6 +344,32 @@
 
     window.addEventListener("hashchange", catchLocationHash.bind(this, false), false);
 
+    d3.select(".search").on("keyup", function () {
+        if (!this.value) {
+            blurNodes();
+            return;
+        }
+
+        var matches = fuzzy.filter(this.value, all).sort(function (a, b) {
+            a.ratio = a.score / a.string.length;
+            b.ratio = b.score / b.string.length;
+            if (a.ratio > b.ratio) {
+                return -1;
+            }
+            if (a.ratio < b.ratio) {
+                return 1;
+            }
+            return 0;
+        });
+
+        if (matches.length > 0) {
+            d3.selectAll(".node").each(function (d) {
+                if (d.name == matches[0].string) {
+                    selectNode.call(this, d, true);
+                }
+            });
+        }
+    });
 </script>
 </body>
 </html>


### PR DESCRIPTION
I added a search box to the interface, which does fuzzy search and focuses on the best match as you type. It makes finding a specific node on the graph a lot easier. [Can be seen here](http://joom.github.io/programming-language-network/).

If you decide to merge this, you should probably also pull the `gh-pages` branch from my fork, to avoid the merge conflict. (It's already resolved in my fork's `gh-pages` branch)